### PR TITLE
small handy updates

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.*"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: "3.*"
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Welcome to echoshader
 
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/OSOceanAcoustics/echoshader/HEAD)
+
 Open Source Python package for building ocean sonar data visualizations based on the HoloViz suite of Python tools.
 
 ## What are ocean sonar systems?

--- a/echoshader/core.py
+++ b/echoshader/core.py
@@ -1,6 +1,6 @@
 import logging
 import warnings
-from typing import List, Union, Optional
+from typing import List, Optional, Union
 
 import holoviews
 import numpy
@@ -288,11 +288,13 @@ class Echoshader(param.Parameterized):
             MVBS_ds_in_gram_box = self.MVBS_ds
 
         else:
-            MVBS_ds_in_gram_box = self.MVBS_ds.sel({
-                "ping_time": slice(bounds[0], bounds[2]),
-                self.vert_dim: slice(bounds[1], bounds[3])
-                if bounds[3] > bounds[1]
-                else slice(bounds[3], bounds[1])},
+            MVBS_ds_in_gram_box = self.MVBS_ds.sel(
+                {
+                    "ping_time": slice(bounds[0], bounds[2]),
+                    self.vert_dim: slice(bounds[1], bounds[3])
+                    if bounds[3] > bounds[1]
+                    else slice(bounds[3], bounds[1]),
+                },
             )
 
         return MVBS_ds_in_gram_box
@@ -382,9 +384,9 @@ class Echoshader(param.Parameterized):
 
         for channel in self.channel:
             echogram = single_echogram(
-                MVBS_ds, 
-                channel, 
-                self.colormap.value, 
+                MVBS_ds,
+                channel,
+                self.colormap.value,
                 self.Sv_range_slider.value,
                 self.vert_dim,
             )

--- a/echoshader/echogram.py
+++ b/echoshader/echogram.py
@@ -36,7 +36,7 @@ def single_echogram(
     value_range : tuple[float, float]
         The minimum and maximum value for the color scale of the echogram.
     vert_dim : str, optional
-        The name of the vertical dimension.
+        The name of the vertical dimension, must be 1D.
 
     Returns
     -------

--- a/echoshader/echogram.py
+++ b/echoshader/echogram.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Union, Optional
+from typing import Dict, List, Optional, Union
 
 import holoviews
 import numpy
@@ -12,7 +12,7 @@ def single_echogram(
     channel: str,
     cmap: Union[str, List[str]],
     value_range: tuple[float, float],
-    vert_dim: Optional[str] = "echo_range", 
+    vert_dim: Optional[str] = "echo_range",
 ):
     """
     Generate an echogram for a single frequency channel.
@@ -132,11 +132,11 @@ def convert_to_color(
 
 
 def tricolor_echogram(
-    MVBS_ds: xarray, 
-    vmin: float, 
-    vmax: float, 
-    rgb_map: Dict[str, str] = {}, 
-    vert_dim: Optional[str] = "echo_range", 
+    MVBS_ds: xarray,
+    vmin: float,
+    vmax: float,
+    rgb_map: Dict[str, str] = {},
+    vert_dim: Optional[str] = "echo_range",
 ):
     """
     Create a tricolor echogram for multiple frequency channels.

--- a/echoshader/echogram.py
+++ b/echoshader/echogram.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Union
+from typing import Dict, List, Union, Optional
 
 import holoviews
 import numpy
@@ -12,6 +12,7 @@ def single_echogram(
     channel: str,
     cmap: Union[str, List[str]],
     value_range: tuple[float, float],
+    vert_dim: Optional[str] = "echo_range", 
 ):
     """
     Generate an echogram for a single frequency channel.
@@ -34,6 +35,8 @@ def single_echogram(
         Input list like ['#0000ff', '#00ffff'] to customize colormap.
     value_range : tuple[float, float]
         The minimum and maximum value for the color scale of the echogram.
+    vert_dim : str, optional
+        The name of the vertical dimension.
 
     Returns
     -------
@@ -67,7 +70,7 @@ def single_echogram(
 
     echogram = (
         holoviews.Dataset(MVBS_ds.sel(channel=channel))
-        .to(holoviews.Image, vdims=["Sv"], kdims=["ping_time", "echo_range"])
+        .to(holoviews.Image, vdims=["Sv"], kdims=["ping_time", vert_dim])
         .opts(gram_opts)
     )
 
@@ -127,7 +130,11 @@ def convert_to_color(
 
 
 def tricolor_echogram(
-    MVBS_ds: xarray, vmin: float, vmax: float, rgb_map: Dict[str, str] = {}
+    MVBS_ds: xarray, 
+    vmin: float, 
+    vmax: float, 
+    rgb_map: Dict[str, str] = {}, 
+    vert_dim: Optional[str] = "echo_range", 
 ):
     """
     Create a tricolor echogram for multiple frequency channels.
@@ -150,6 +157,8 @@ def tricolor_echogram(
         The keys are the frequency channel names, and the values are the corresponding
         RGB channel names. If not provided, the function will assign the first three frequency
         channels to the "R", "G", and "B" channels, respectively.
+    vert_dim : str, optional
+        Name of vertical dimension. Default is echo_range.
 
     Returns
     -------
@@ -194,7 +203,7 @@ def tricolor_echogram(
     rgb = holoviews.RGB(
         (
             MVBS_ds.ping_time.data,
-            MVBS_ds.echo_range.data,
+            MVBS_ds[vert_dim].data,
             rgb_ch["R"],
             rgb_ch["G"],
             rgb_ch["B"],

--- a/echoshader/echogram.py
+++ b/echoshader/echogram.py
@@ -119,7 +119,7 @@ def convert_to_color(
     da_color = da_color.where(
         da_color <= th_top, other=th_top
     )  # set to ceiling at the top
-    da_color = da_color.where(da_color >= th_bottom)  # threshold at the bottom
+    da_color = da_color.where(da_color >= th_bottom, other=th_bottom)  # threshold at the bottom
     da_color = da_color.expand_dims("channel")
     da_color = (da_color - th_bottom) / (th_top - th_bottom)
     da_color = numpy.squeeze(da_color.Sv.data).transpose().compute()


### PR DESCRIPTION
* clipping tricolor to thresholds
* adding an option to specify `vert_dim` to use for echogram. This allows to specify a dimension different from `echo_range`, for example `depth`
* pinning testing to python 3.11 (and updating to latest actions), since there is an issue with `aiohttp` on 3.12.
* adding binder link