### PR TITLE
remove compute after numpy squeeze

### DIFF
--- a/echoshader/echogram.py
+++ b/echoshader/echogram.py
@@ -127,7 +127,7 @@ def convert_to_color(
     )  # threshold at the bottom
     da_color = da_color.expand_dims("channel")
     da_color = (da_color - th_bottom) / (th_top - th_bottom)
-    da_color = numpy.squeeze(da_color.Sv.data).transpose().compute()
+    da_color = numpy.squeeze(da_color.Sv.data).transpose()
     return da_color
 
 


### PR DESCRIPTION
Addressing this issue with #173. The current tests are passing. I added an issue #177 to verify there are tests for dask and numpy input datasets. 