### PR TITLE
fix: Update zarr>=3, keep numpy<2 pin, and test notebooks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,12 +3,12 @@ hvplot
 ipykernel
 geoviews
 netCDF4>1.6
-numpy>=1.26.4,<3
+numpy<2
 pandas
 pyvista[jupyter]
 plotly
 xarray>=2024.11.0
-zarr==2.16.1
+zarr>=3
 panel
 jupyter_bokeh
 echopype


### PR DESCRIPTION
Hey @LOCEANlloydizard! I went ahead and updated to zarr>=3 and tested the notebooks, but ran into a few interesting things along the way. I initially tried unpinning NumPy completely, but since NumPy 2.x causes netCDF4 to crash with a dtype size error, I put the numpy<2 pin back in for now so the notebooks actually run. I also noticed that the Zarr 3 update seems to break ep.commongrid.compute_MVBS() in get_ship_data; I dug into the traceback and found it failing deep in flox when it tries to index a PyArrow ChunkedArray (throwing a TypeError about integer scalar arrays). The try/except block swallows it so the cell doesn't completely halt, but I want to flag that upstream bug for you. Lastly, the GitHub Actions failed on the Python 3.10 runner because Zarr 3 officially requires Python >=3.11. Since the tests passed perfectly on 3.11 and 3.12, we might just need to drop 3.10 from the workflow entirely. The updated requirements.txt is in this PR, so just let me know how you'd like to handle the CI matrix!